### PR TITLE
Explicitly initialize UserConfig values to avoid undefined dereference.

### DIFF
--- a/saved_search.rb
+++ b/saved_search.rb
@@ -9,6 +9,7 @@ module Plugin::SavedSearch
 end
 
 Plugin.create :saved_search do
+  UserConfig[:retrieve_interval_search] ||= 60
 
   counter = gen_counter
 


### PR DESCRIPTION
https://github.com/mikutter/rest/issues/1
で挙がった UserConfig の interval 値の初期値追加です