### PR TITLE
fixed: URI.decodeの変わりにCGI.unescapeを使う

### DIFF
--- a/saved_search.rb
+++ b/saved_search.rb
@@ -156,15 +156,7 @@ Plugin.create :saved_search do
         zombie_tab = tab(s[:slug])
         zombie_tab.destroy if zombie_tab end }
   end
-  
+
   Delayer.new{ refresh(true) }
 
 end
-
-
-
-
-
-
-
-

--- a/saved_search.rb
+++ b/saved_search.rb
@@ -95,8 +95,8 @@ Plugin.create :saved_search do
         saved_searches = {}
         res.each{ |record|
           saved_searches[record[:id]] = Plugin::SavedSearch::SavedSearch.new(record[:id],
-                                                                             URI.decode(record[:query]),
-                                                                             URI.decode(record[:name]),
+                                                                             CGI.unescape(record[:query]),
+                                                                             CGI.unescape(record[:name]),
                                                                              :"savedsearch_#{record[:id]}",
                                                                              service) }
         new_ids = saved_searches.keys
@@ -148,8 +148,8 @@ Plugin.create :saved_search do
       service = service_by_user_id(s[:service_id])
       if service
         add_tab(Plugin::SavedSearch::SavedSearch.new(s[:id],
-                                                     URI.decode(s[:query]),
-                                                     URI.decode(s[:name]),
+                                                     CGI.unescape(s[:query]),
+                                                     CGI.unescape(s[:name]),
                                                      s[:slug],
                                                      service))
       elsif s[:slug]


### PR DESCRIPTION
元々非推奨メソッドで、
Ruby 3.0.0で消えたため。
`URI.decode_www_form`は日本語などの文字列を処理できないので、
`CGI.unescape`の方を使っています。